### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paramscode/api-app/security/code-scanning/1](https://github.com/paramscode/api-app/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the tasks performed in the workflow, the minimal required permission is `contents: read`, which allows the workflow to read repository contents without granting write access.

The `permissions` block should be added immediately after the `name` field at the top of the file. This ensures that the workflow explicitly limits the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
